### PR TITLE
changing declaration of Rij to run the simulation in a single patch

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -533,7 +533,7 @@ function init_pop_param_struct(G::Int64, M::Int64,
     σ = pop_params_dict["σ"]
 
     edgelist = Array{Int64, 2}(network_df[:, 1:2])
-    Rᵢⱼ      = copy(network_df[:, 3])
+    Rᵢⱼ      = Array{Float64}(network_df[:, 3])
     edgelist, Rᵢⱼ = correct_self_loops(edgelist, Rᵢⱼ, M)
     pop_params    = Population_Params(G, M, nᵢᵍ, kᵍ, kᵍ_h, kᵍ_w, C, pᵍ, edgelist, Rᵢⱼ, sᵢ, ξ, σ)
 


### PR DESCRIPTION
Declaring Rij to ensure that is always an array, even when there is a single patch